### PR TITLE
Actually use the results of FindFFTS

### DIFF
--- a/scopeprotocols/CMakeLists.txt
+++ b/scopeprotocols/CMakeLists.txt
@@ -38,9 +38,10 @@ add_library(scopeprotocols SHARED
 	${SCOPEPROTOCOLS_SOURCES})
 
 target_link_libraries(scopeprotocols
-	ffts)
+	${LIBFFTS_LIBRARIES})
 
 target_include_directories(scopeprotocols
-PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+PRIVATE ${LIBFFTS_INCLUDE_DIR})
 
 install(TARGETS scopeprotocols LIBRARY DESTINATION /usr/lib)

--- a/scopeprotocols/FFTDecoder.cpp
+++ b/scopeprotocols/FFTDecoder.cpp
@@ -30,7 +30,7 @@
 #include "../scopehal/scopehal.h"
 #include "FFTDecoder.h"
 #include "../scopehal/AnalogRenderer.h"
-#include <ffts/ffts.h>
+#include <ffts.h>
 
 using namespace std;
 


### PR DESCRIPTION
Right now a system ffts library is blindly used without regard to the found package.