### PR TITLE
Add an incomplete CAN decoder

### DIFF
--- a/scopeprotocols/CANDecoder.cpp
+++ b/scopeprotocols/CANDecoder.cpp
@@ -1,0 +1,309 @@
+/**
+	@file
+	@author Andrés MANELLI
+	@brief Implementation of CANDecoder
+ */
+
+#include "../scopehal/scopehal.h"
+#include "../scopehal/ChannelRenderer.h"
+#include "../scopehal/TextRenderer.h"
+#include "CANRenderer.h"
+#include "CANDecoder.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+CANDecoder::CANDecoder(string color)
+	: ProtocolDecoder(OscilloscopeChannel::CHANNEL_TYPE_COMPLEX, color, CAT_SERIAL)
+{
+	//Set up channels
+	m_signalNames.push_back("Diff");
+	m_channels.push_back(NULL);
+
+	m_tq = "Time Quantum [ns]";
+	m_parameters[m_tq] = ProtocolDecoderParameter(ProtocolDecoderParameter::TYPE_INT);
+	m_parameters[m_tq].SetIntVal(156);
+
+	m_bs1 = "Bit Segment 1 [tq]";
+	m_parameters[m_bs1] = ProtocolDecoderParameter(ProtocolDecoderParameter::TYPE_INT);
+	m_parameters[m_bs1].SetIntVal(7);
+
+	m_bs2 = "Bit Segment 2 [tq]";
+	m_parameters[m_bs2] = ProtocolDecoderParameter(ProtocolDecoderParameter::TYPE_INT);
+	m_parameters[m_bs2].SetIntVal(5);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Factory methods
+
+bool CANDecoder::NeedsConfig()
+{
+	return true;
+}
+
+ChannelRenderer* CANDecoder::CreateRenderer()
+{
+	return new CANRenderer(this);
+}
+
+bool CANDecoder::ValidateChannel(size_t i, OscilloscopeChannel* channel)
+{
+	if( (i == 0) && (channel->GetType() == OscilloscopeChannel::CHANNEL_TYPE_DIGITAL) && (channel->GetWidth() == 1) )
+		return true;
+	return false;
+}
+
+string CANDecoder::GetProtocolName()
+{
+	return "CAN";
+}
+
+void CANDecoder::SetDefaultName()
+{
+	char hwname[256];
+	snprintf(hwname, sizeof(hwname), "CAN(%s)", m_channels[0]->m_displayname.c_str());
+	m_hwname = hwname;
+	m_displayname = m_hwname;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Actual decoder logic
+
+void CANDecoder::Refresh()
+{
+	//Get the input data
+	if( (m_channels[0] == NULL) )
+	{
+		SetData(NULL);
+		return;
+	}
+
+	DigitalCapture* diff = dynamic_cast<DigitalCapture*>(m_channels[0]->GetData());
+	if( (diff == NULL) )
+	{
+		SetData(NULL);
+		return;
+	}
+
+	//Create the capture
+	CANCapture* cap = new CANCapture;
+	cap->m_timescale = diff->m_timescale;
+	cap->m_startTimestamp = diff->m_startTimestamp;
+	cap->m_startPicoseconds = diff->m_startPicoseconds;
+
+	//Loop over the data and look for transactions
+	//For now, assume equal sample rate
+	bool last_diff = true;
+	bool cur_diff = true;
+	size_t symbol_start = 0;
+	size_t bit_start = 0;
+	CANSymbol::stype current_symbol = CANSymbol::TYPE_IDLE;
+	uint32_t current_data = 0;
+	uint8_t bitcount = 0;
+	uint8_t dlc = 0;
+	uint8_t stuff = 0;
+
+	// Sync_seg + bs1 + bs2
+	// FIXME
+	m_nbt = m_parameters[m_tq].GetIntVal() * ( 1 + m_parameters[m_bs1].GetIntVal() + m_parameters[m_bs2].GetIntVal() );
+
+	for(size_t i = 0; i < diff->m_samples.size(); i++)
+	{
+		if (symbol_start != 0 && current_symbol == CANSymbol::TYPE_SOF &&
+		    ((diff->m_samples[i].m_offset - diff->m_samples[bit_start].m_offset + 1) * diff->m_timescale)
+		    <
+		    ((2 * m_parameters[m_bs1].GetIntVal() + 1) * m_parameters[m_tq].GetIntVal() * 500))
+		{
+			// We wait for the next bit
+			continue;
+		} else if (symbol_start != 0 && current_symbol != CANSymbol::TYPE_SOF &&
+		    ((diff->m_samples[i].m_offset - diff->m_samples[bit_start].m_offset + 1) * diff->m_timescale) < (m_nbt * 1e3))
+		{
+			// We wait for the next bit
+			continue;
+		}
+
+		cur_diff = diff->m_samples[i].m_sample;
+		bit_start = i;
+
+		if (current_symbol != CANSymbol::TYPE_IDLE)
+		{
+			if (stuff == 5)
+			{
+				// Ignore bit
+				stuff = 1;
+				last_diff = cur_diff;
+				continue;
+			} else if (cur_diff == last_diff || stuff == 0) {
+				stuff++;
+			} else {
+				stuff = 1;
+			}
+		}
+
+		// First bit
+		if (current_symbol == CANSymbol::TYPE_IDLE && cur_diff && !last_diff)
+		{
+			symbol_start = i;
+			current_symbol = CANSymbol::TYPE_SOF;
+			stuff = 1;
+		}
+		else if (current_symbol == CANSymbol::TYPE_SOF)
+		{
+			cap->m_samples.push_back(CANSample(
+					diff->m_samples[symbol_start].m_offset,
+					diff->m_samples[i].m_offset - symbol_start,
+					CANSymbol(CANSymbol::TYPE_SOF, NULL, 0)
+				)
+			);
+
+			current_symbol = CANSymbol::TYPE_SID;
+			symbol_start = i;
+		}
+		else if (current_symbol == CANSymbol::TYPE_SID)
+		{
+			current_data <<= 1;
+			current_data |= (cur_diff)?0:1;
+			bitcount++;
+
+			if (bitcount == 11) // SID
+			{
+				cap->m_samples.push_back(CANSample(
+						diff->m_samples[symbol_start].m_offset,
+						diff->m_samples[i].m_offset - symbol_start,
+						CANSymbol(CANSymbol::TYPE_SID, (uint8_t*)&current_data, 2)
+					)
+				);
+
+				bitcount = 0;
+				current_data = 0;
+				symbol_start = i;
+				current_symbol = CANSymbol::TYPE_RTR;
+			}
+		}
+		else if (current_symbol == CANSymbol::TYPE_RTR)
+		{
+			current_data |= (cur_diff)?0:1;
+
+			cap->m_samples.push_back(CANSample(
+					diff->m_samples[symbol_start].m_offset,
+					diff->m_samples[i].m_offset - symbol_start,
+					CANSymbol(CANSymbol::TYPE_RTR, (uint8_t *)&current_data, 1)
+				)
+			);
+
+			current_data = 0;
+			symbol_start = i;
+			current_symbol = CANSymbol::TYPE_IDE;
+		}
+		else if (current_symbol == CANSymbol::TYPE_IDE)
+		{
+			current_data |= (cur_diff)?0:1;
+
+			cap->m_samples.push_back(CANSample(
+					diff->m_samples[symbol_start].m_offset,
+					diff->m_samples[i].m_offset - symbol_start,
+					CANSymbol(CANSymbol::TYPE_IDE, (uint8_t *)&current_data, 1)
+				)
+			);
+
+			current_data = 0;
+			symbol_start = i;
+			current_symbol = CANSymbol::TYPE_R0;
+		}
+		else if (current_symbol == CANSymbol::TYPE_R0)
+		{
+			current_data |= (cur_diff)?0:1;
+
+			cap->m_samples.push_back(CANSample(
+					diff->m_samples[symbol_start].m_offset,
+					diff->m_samples[i].m_offset - symbol_start,
+					CANSymbol(CANSymbol::TYPE_R0, (uint8_t *)&current_data, 1)
+				)
+			);
+
+			current_data = 0;
+			symbol_start = i;
+			current_symbol = CANSymbol::TYPE_DLC;
+		}
+		else if (current_symbol == CANSymbol::TYPE_DLC)
+		{
+			bitcount++;
+			current_data <<= 1;
+			current_data |= (cur_diff)?0:1;
+
+			if (bitcount == 4)
+			{
+				cap->m_samples.push_back(CANSample(
+						diff->m_samples[symbol_start].m_offset,
+						diff->m_samples[i].m_offset - symbol_start,
+						CANSymbol(CANSymbol::TYPE_DLC, (uint8_t*)&current_data, 1)
+					)
+				);
+
+				dlc = current_data;
+				bitcount = 0;
+				current_data = 0;
+				symbol_start = i;
+				current_symbol = CANSymbol::TYPE_DATA;
+			}
+		}
+		else if (current_symbol == CANSymbol::TYPE_DATA)
+		{
+			bitcount++;
+			current_data <<= 1;
+			current_data |= (cur_diff)?0:1;
+
+			if (bitcount == 8)
+			{
+				cap->m_samples.push_back(CANSample(
+						diff->m_samples[symbol_start].m_offset,
+						diff->m_samples[i].m_offset - symbol_start,
+						CANSymbol(CANSymbol::TYPE_DATA, (uint8_t*)&current_data, 1)
+					)
+				);
+
+				bitcount = 0;
+				current_data = 0;
+				symbol_start = i;
+				--dlc;
+				if (0 == dlc)
+				{
+					current_symbol = CANSymbol::TYPE_CRC;
+				}
+				else
+				{
+					current_symbol = CANSymbol::TYPE_DATA;
+				}
+			}
+		}
+		else if (current_symbol == CANSymbol::TYPE_CRC)
+		{
+			bitcount++;
+			current_data <<= 1;
+			current_data |= (cur_diff)?0:1;
+
+			if (bitcount == 15)
+			{
+				cap->m_samples.push_back(CANSample(
+						diff->m_samples[symbol_start].m_offset,
+						diff->m_samples[i].m_offset - symbol_start,
+						CANSymbol(CANSymbol::TYPE_CRC, (uint8_t*)&current_data, 2)
+					)
+				);
+
+				bitcount = 0;
+				current_data = 0;
+				symbol_start = 0;
+				current_symbol = CANSymbol::TYPE_IDLE;
+			}
+		}
+
+		//Save old state
+		last_diff = cur_diff;
+	}
+
+	SetData(cap);
+}

--- a/scopeprotocols/CANDecoder.h
+++ b/scopeprotocols/CANDecoder.h
@@ -1,0 +1,73 @@
+/**
+	@file
+	@author Andrés MANELLI
+	@brief Declaration of CANDecoder
+ */
+
+#ifndef CANDecoder_h
+#define CANDecoder_h
+
+#include "../scopehal/ProtocolDecoder.h"
+
+class CANSymbol
+{
+public:
+	enum stype
+	{
+		TYPE_SOF,
+		TYPE_SID,
+		TYPE_RTR,
+		TYPE_IDE,
+		TYPE_R0,
+		TYPE_DLC,
+		TYPE_DATA,
+		TYPE_CRC,
+		TYPE_IDLE
+	};
+
+	CANSymbol(stype t, uint8_t *data, size_t size)
+	 : m_stype(t)
+	{
+		for (uint8_t i = 0; i < size; i++)
+		{
+			m_data.push_back(data[i]);
+		}
+	}
+
+	stype m_stype;
+	std::vector<uint8_t> m_data;
+
+	bool operator== (const CANSymbol& s) const
+	{
+		return (m_stype == s.m_stype) && (m_data == s.m_data);
+	}
+};
+
+typedef OscilloscopeSample<CANSymbol> CANSample;
+typedef CaptureChannel<CANSymbol> CANCapture;
+
+class CANDecoder : public ProtocolDecoder
+{
+public:
+	CANDecoder(std::string color);
+
+	virtual void Refresh();
+	virtual ChannelRenderer* CreateRenderer();
+	virtual bool NeedsConfig();
+
+	static std::string GetProtocolName();
+	virtual void SetDefaultName();
+
+	virtual bool ValidateChannel(size_t i, OscilloscopeChannel* channel);
+
+	PROTOCOL_DECODER_INITPROC(CANDecoder)
+
+protected:
+	std::string m_tq;
+	std::string m_bs1, m_bs2;
+
+	// Nominal Bit Time, in ns
+	unsigned int m_nbt;
+};
+
+#endif

--- a/scopeprotocols/CANRenderer.cpp
+++ b/scopeprotocols/CANRenderer.cpp
@@ -1,0 +1,109 @@
+/**
+	@file
+	@author Andrés MANELLI
+	@brief Declaration of CANRenderer
+ */
+
+#include "scopeprotocols.h"
+#include "../scopehal/scopehal.h"
+#include "../scopehal/ChannelRenderer.h"
+#include "../scopehal/TextRenderer.h"
+#include "CANRenderer.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+CANRenderer::CANRenderer(OscilloscopeChannel* channel)
+: TextRenderer(channel)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Rendering
+
+Gdk::Color CANRenderer::GetColor(int i)
+{
+	CANCapture* capture = dynamic_cast<CANCapture*>(m_channel->GetData());
+	if(capture != NULL)
+	{
+		const CANSymbol& s = capture->m_samples[i].m_sample;
+
+		if(s.m_stype == CANSymbol::TYPE_SOF)
+			return m_standardColors[COLOR_CONTROL];
+		else if(s.m_stype == CANSymbol::TYPE_SID)
+			return m_standardColors[COLOR_ADDRESS];
+		else if(s.m_stype == CANSymbol::TYPE_RTR)
+			return m_standardColors[COLOR_CONTROL];
+		else if(s.m_stype == CANSymbol::TYPE_IDE)
+			return m_standardColors[COLOR_CONTROL];
+		else if(s.m_stype == CANSymbol::TYPE_R0)
+			return m_standardColors[COLOR_CONTROL];
+		else if(s.m_stype == CANSymbol::TYPE_DLC)
+			return m_standardColors[COLOR_CONTROL];
+		else if(s.m_stype == CANSymbol::TYPE_DATA)
+			return m_standardColors[COLOR_DATA];
+		else if(s.m_stype == CANSymbol::TYPE_CRC)
+			return m_standardColors[COLOR_CHECKSUM_OK];
+		else
+			return m_standardColors[COLOR_IDLE];
+	}
+
+	return m_standardColors[COLOR_ERROR];
+}
+
+string CANRenderer::GetText(int i)
+{
+	CANCapture* capture = dynamic_cast<CANCapture*>(m_channel->GetData());
+	if(capture != NULL)
+	{
+		const CANSymbol& s = capture->m_samples[i].m_sample;
+
+		char tmp[32];
+		switch(s.m_stype)
+		{
+			case CANSymbol::TYPE_SOF:
+				snprintf(tmp, sizeof(tmp), "SOF");
+				break;
+			case CANSymbol::TYPE_SID:
+				{
+					uint16_t sid = 0;
+					sid += s.m_data[1];
+					sid <<= 8;
+					sid += s.m_data[0];
+					snprintf(tmp, sizeof(tmp), "SID: %02x", sid);
+				}
+				break;
+			case CANSymbol::TYPE_RTR:
+				snprintf(tmp, sizeof(tmp), "RTR: %u", s.m_data[0]);
+				break;
+			case CANSymbol::TYPE_IDE:
+				snprintf(tmp, sizeof(tmp), "IDE: %u", s.m_data[0]);
+				break;
+			case CANSymbol::TYPE_R0:
+				snprintf(tmp, sizeof(tmp), "R0: %u", s.m_data[0]);
+				break;
+			case CANSymbol::TYPE_DLC:
+				snprintf(tmp, sizeof(tmp), "DLC: %u", s.m_data[0]);
+				break;
+			case CANSymbol::TYPE_DATA:
+				snprintf(tmp, sizeof(tmp), "%02x", s.m_data[0]);
+				break;
+			case CANSymbol::TYPE_CRC:
+				{
+					uint16_t crc = 0;
+					crc += s.m_data[1];
+					crc <<= 8;
+					crc += s.m_data[0];
+					snprintf(tmp, sizeof(tmp), "CRC: %02x", crc);
+				}
+				break;
+			default:
+				snprintf(tmp, sizeof(tmp), "ERR");
+				break;
+		}
+		return string(tmp);
+	}
+	return "";
+}

--- a/scopeprotocols/CANRenderer.h
+++ b/scopeprotocols/CANRenderer.h
@@ -1,0 +1,25 @@
+/**
+  @file
+  @author Andrés MANELLI
+  @brief Declaration of CANRenderer
+  */
+
+#ifndef CANRenderer_h
+#define CANRenderer_h
+
+#include "../scopehal/TextRenderer.h"
+
+/**
+  @brief Renderer for a CAN channel
+  */
+class CANRenderer : public TextRenderer
+{
+public:
+	CANRenderer(OscilloscopeChannel* channel);
+
+protected:
+	virtual std::string GetText(int i);
+	virtual Gdk::Color GetColor(int i);
+};
+
+#endif

--- a/scopeprotocols/CMakeLists.txt
+++ b/scopeprotocols/CMakeLists.txt
@@ -18,6 +18,8 @@ set(SCOPEPROTOCOLS_SOURCES
 	FFTDecoder.cpp
 	I2CDecoder.cpp
 	I2CRenderer.cpp
+	CANDecoder.cpp
+	CANRenderer.cpp
 	IBM8b10bDecoder.cpp
 	IBM8b10bRenderer.cpp
 	JtagDecoder.cpp

--- a/scopeprotocols/scopeprotocols.cpp
+++ b/scopeprotocols/scopeprotocols.cpp
@@ -53,6 +53,7 @@ void ScopeProtocolStaticInit()
 	AddDecoderClass(FFTDecoder);
 	AddDecoderClass(IBM8b10bDecoder);
 	AddDecoderClass(I2CDecoder);
+	AddDecoderClass(CANDecoder);
 	AddDecoderClass(JtagDecoder);
 	AddDecoderClass(MDIODecoder);
 	AddDecoderClass(SincInterpolationDecoder);

--- a/scopeprotocols/scopeprotocols.h
+++ b/scopeprotocols/scopeprotocols.h
@@ -53,6 +53,7 @@
 #include "FFTDecoder.h"
 #include "IBM8b10bDecoder.h"
 #include "I2CDecoder.h"
+#include "CANDecoder.h"
 #include "JtagDecoder.h"
 #include "MDIODecoder.h"
 #include "SincInterpolationDecoder.h"


### PR DESCRIPTION
This PR adds an incomplete CAN decoder, i.e.: standard frame ID only, no CRC verification, no transmission error check (partially implements #32)

Other than that, I think it works _pas mal_ at least in my tests. I didn't want to delay the PR.

I will continue to add improvements as I can.

Please let me know if I can make any modification.