### PR TITLE
Fixes to allow compilation on Win32

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -3,6 +3,14 @@ link_directories(${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 find_library(LXI_LIB lxi)
 
+if(LXI_LIB)
+	set(HAS_LXI true)
+	set(LXI_LIBRARIES ${LXI_LIB})
+else()
+	set(HAS_LXI false)
+	set(LXI_LIBRARIES "")
+endif()
+
 set(SCOPEHAL_SOURCES
 	base64.cpp
 	scopehal.cpp
@@ -41,9 +49,13 @@ set(SCOPEHAL_SOURCES
 
 add_library(scopehal SHARED
 	${SCOPEHAL_SOURCES})
-target_link_libraries(scopehal ${SIGCXX_LIBRARIES} ${GTKMM_LIBRARIES} xptools log graphwidget yaml-cpp ${LXI_LIB})
+target_link_libraries(scopehal ${SIGCXX_LIBRARIES} ${GTKMM_LIBRARIES} xptools log graphwidget yaml-cpp ${LXI_LIBRARIES})
 
 target_include_directories(scopehal
 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(${HAS_LXI})
+	target_compile_definitions(scopehal PUBLIC HAS_LXI)
+endif()
 
 install(TARGETS scopehal LIBRARY DESTINATION /usr/lib)

--- a/scopehal/LeCroyOscilloscope.cpp
+++ b/scopehal/LeCroyOscilloscope.cpp
@@ -27,6 +27,8 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifndef _WIN32
+
 #include "scopehal.h"
 #include "LeCroyOscilloscope.h"
 #include "ProtocolDecoder.h"
@@ -2153,3 +2155,5 @@ int64_t LeCroyOscilloscope::GetDeskewForChannel(size_t channel)
 
 	return skew_ps;
 }
+
+#endif

--- a/scopehal/LeCroyOscilloscope.h
+++ b/scopehal/LeCroyOscilloscope.h
@@ -27,6 +27,8 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifndef _WIN32
+
 #ifndef LeCroyOscilloscope_h
 #define LeCroyOscilloscope_h
 
@@ -241,5 +243,7 @@ public:
 	static std::string GetDriverNameInternal();
 	OSCILLOSCOPE_INITPROC(LeCroyOscilloscope)
 };
+
+#endif
 
 #endif

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -27,6 +27,11 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifdef _WIN32
+#include <chrono>
+#include <thread>
+#endif
+
 #include "scopehal.h"
 #include "RigolOscilloscope.h"
 
@@ -463,7 +468,11 @@ void RigolOscilloscope::ResetTriggerConditions()
 Oscilloscope::TriggerMode RigolOscilloscope::PollTrigger()
 {
 	//workaround for high latency links to let the UI thread get the mutex
+#ifdef _WIN32
+	std::this_thread::sleep_for(std::chrono::microseconds(1000));
+#else
 	usleep(1000);
+#endif
 
 	lock_guard<recursive_mutex> lock(m_mutex);
 
@@ -502,7 +511,11 @@ bool RigolOscilloscope::AcquireData(bool toQueue)
 	bool enabled[4] = {true, true, true, true};
 
 	//workaround for high latency links to let the UI thread get the mutex
+#ifdef _WIN32
+	std::this_thread::sleep_for(std::chrono::microseconds(1000));
+#else
 	usleep(1000);
+#endif
 
 	lock_guard<recursive_mutex> lock(m_mutex);
 	LogIndenter li;

--- a/scopehal/SCPILxiTransport.cpp
+++ b/scopehal/SCPILxiTransport.cpp
@@ -225,4 +225,4 @@ bool SCPILxiTransport::IsCommandBatchingSupported()
 	return false;
 }
 
-#endif HAS_LXI
+#endif

--- a/scopehal/SCPILxiTransport.cpp
+++ b/scopehal/SCPILxiTransport.cpp
@@ -32,6 +32,8 @@
 	@author Tom Verbeure 
 	@brief Implementation of SCPILxiTransport
  */
+ 
+#ifdef HAS_LXI
 
 extern "C"
 {
@@ -222,3 +224,5 @@ bool SCPILxiTransport::IsCommandBatchingSupported()
 {
 	return false;
 }
+
+#endif HAS_LXI

--- a/scopehal/SCPILxiTransport.h
+++ b/scopehal/SCPILxiTransport.h
@@ -33,6 +33,8 @@
 	@brief Declaration of SCPILxiTransport
  */
 
+#ifdef HAS_LXI
+
 #ifndef SCPILxiTransport_h
 #define SCPILxiTransport_h
 
@@ -76,5 +78,7 @@ protected:
 	int m_data_offset;
 	bool m_data_depleted;
 };
+
+#endif
 
 #endif

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -27,6 +27,8 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifndef _WIN32
+
 #include "scopehal.h"
 #include "SiglentSCPIOscilloscope.h"
 #include "ProtocolDecoder.h"
@@ -398,3 +400,5 @@ bool SiglentSCPIOscilloscope::AcquireData(bool toQueue)
 
 	return true;
 }
+
+#endif

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -27,6 +27,8 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifndef _WIN32
+
 #ifndef SiglentSCPIOscilloscope_h
 #define SiglentSCPIOscilloscope_h
 
@@ -202,5 +204,7 @@ struct SiglentWaveformDesc_t
 	*/
 	uint16_t WaveformSource;
 };
+
+#endif
 
 #endif

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -42,7 +42,10 @@
 #include "RohdeSchwarzOscilloscope.h"
 #include "SiglentSCPIOscilloscope.h"
 #include <libgen.h>
+
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 
 using namespace std;
 
@@ -52,9 +55,12 @@ using namespace std;
 void TransportStaticInit()
 {
 	AddTransportClass(SCPISocketTransport);
-	AddTransportClass(SCPILxiTransport);
 	AddTransportClass(SCPITMCTransport);
 	AddTransportClass(VICPSocketTransport);
+	
+#ifdef HAS_LXI
+	AddTransportClass(SCPILxiTransport);
+#endif
 }
 
 /**
@@ -65,10 +71,13 @@ void DriverStaticInit()
 	AddDriverClass(AgilentOscilloscope);
 	AddDriverClass(AntikernelLabsOscilloscope);
 	AddDriverClass(AntikernelLogicAnalyzer);
-	AddDriverClass(LeCroyOscilloscope);
 	AddDriverClass(RigolOscilloscope);
 	AddDriverClass(RohdeSchwarzOscilloscope);
+	
+#ifndef _WIN32
+	AddDriverClass(LeCroyOscilloscope);
 	AddDriverClass(SiglentSCPIOscilloscope);
+#endif
 }
 
 string GetDefaultChannelColor(int i)
@@ -109,6 +118,7 @@ uint64_t ConvertVectorSignalToScalar(vector<bool> bits)
  */
 void InitializePlugins()
 {
+#ifndef _WIN32
 	char tmp[1024];
 	vector<string> search_dirs;
 	search_dirs.push_back("/usr/lib/scopehal/plugins/");
@@ -157,4 +167,5 @@ void InitializePlugins()
 
 		closedir(hdir);
 	}
+#endif
 }

--- a/scopeprotocols/CMakeLists.txt
+++ b/scopeprotocols/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(scopeprotocols SHARED
 	${SCOPEPROTOCOLS_SOURCES})
 
 target_link_libraries(scopeprotocols
+	scopehal
 	${LIBFFTS_LIBRARIES})
 
 target_include_directories(scopeprotocols

--- a/scopeprotocols/SincInterpolationDecoder.cpp
+++ b/scopeprotocols/SincInterpolationDecoder.cpp
@@ -27,6 +27,11 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif
+
 #include "../scopehal/scopehal.h"
 #include "SincInterpolationDecoder.h"
 


### PR DESCRIPTION
This PR contains various fixes that allow scopehal and scopeprotocols to be compiled on Win32.