### PR TITLE
Implemented plugin loading for Win32

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -3,6 +3,11 @@ link_directories(${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 find_library(LXI_LIB lxi)
 
+# Additional WinAPI libraries
+if(WIN32)
+	set(WIN_LIBS shlwapi)
+endif()
+
 if(LXI_LIB)
 	set(HAS_LXI true)
 	set(LXI_LIBRARIES ${LXI_LIB})
@@ -49,7 +54,7 @@ set(SCOPEHAL_SOURCES
 
 add_library(scopehal SHARED
 	${SCOPEHAL_SOURCES})
-target_link_libraries(scopehal ${SIGCXX_LIBRARIES} ${GTKMM_LIBRARIES} xptools log graphwidget yaml-cpp ${LXI_LIBRARIES})
+target_link_libraries(scopehal ${SIGCXX_LIBRARIES} ${GTKMM_LIBRARIES} xptools log graphwidget yaml-cpp ${LXI_LIBRARIES} ${WIN_LIBS})
 
 target_include_directories(scopehal
 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
- Currently, the loader only searches in the `/plugins/` subdirectory of the folder the binary is located in. This is common for Windows software.
- Only files ending in `*.dll` are supported