### PR TITLE
set rx/tx timeout after connect, to avoid it being reset

### DIFF
--- a/scopehal/SCPISocketTransport.cpp
+++ b/scopehal/SCPISocketTransport.cpp
@@ -59,15 +59,18 @@ SCPISocketTransport::SCPISocketTransport(string args)
 
 	LogDebug("Connecting to SCPI oscilloscope at %s:%d\n", m_hostname.c_str(), m_port);
 
-	m_socket.SetRxTimeout(2000000);
-	m_socket.SetTxTimeout(2000000);
-
 	if(!m_socket.Connect(m_hostname, m_port))
 	{
 		m_socket.Close();
 		LogError("Couldn't connect to socket\n");
 		return;
 	}
+	if(!m_socket.SetRxTimeout(2000000)) {
+		LogWarning("No Rx timeout: %s\n", strerror(errno));
+    }
+	if(!m_socket.SetTxTimeout(2000000)) {
+		LogWarning("No Tx timeout: %s\n", strerror(errno));
+    }
 	if(!m_socket.DisableNagle())
 	{
 		m_socket.Close();

--- a/scopehal/SCPISocketTransport.cpp
+++ b/scopehal/SCPISocketTransport.cpp
@@ -65,12 +65,10 @@ SCPISocketTransport::SCPISocketTransport(string args)
 		LogError("Couldn't connect to socket\n");
 		return;
 	}
-	if(!m_socket.SetRxTimeout(2000000)) {
+	if(!m_socket.SetRxTimeout(2000000))
 		LogWarning("No Rx timeout: %s\n", strerror(errno));
-    }
-	if(!m_socket.SetTxTimeout(2000000)) {
+	if(!m_socket.SetTxTimeout(2000000))
 		LogWarning("No Tx timeout: %s\n", strerror(errno));
-    }
 	if(!m_socket.DisableNagle())
 	{
 		m_socket.Close();


### PR DESCRIPTION
It appears that setting a timeout before connecting just gets reset. So setting the timeout after connecting fixes the problem.

This fix depends on https://github.com/azonenberg/xptools/pull/12