### PR TITLE
Fix ffts include path

### DIFF
--- a/scopeprotocols/CMakeLists.txt
+++ b/scopeprotocols/CMakeLists.txt
@@ -87,6 +87,6 @@ target_link_libraries(scopeprotocols
 
 target_include_directories(scopeprotocols
 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-PRIVATE ${LIBFFTS_INCLUDE_DIR})
+       ${LIBFFTS_INCLUDE_DIR})
 
 install(TARGETS scopeprotocols LIBRARY DESTINATION /usr/lib)

--- a/scopeprotocols/DeEmbedFilter.h
+++ b/scopeprotocols/DeEmbedFilter.h
@@ -36,7 +36,7 @@
 #define DeEmbedFilter_h
 
 #include "../scopehal/AlignedAllocator.h"
-#include <ffts/ffts.h>
+#include <ffts.h>
 
 class DeEmbedFilter : public Filter
 {

--- a/scopeprotocols/FFTFilter.h
+++ b/scopeprotocols/FFTFilter.h
@@ -35,7 +35,7 @@
 #ifndef FFTFilter_h
 #define FFTFilter_h
 
-#include <ffts/ffts.h>
+#include <ffts.h>
 
 class FFTFilter : public Filter
 {

--- a/scopeprotocols/OFDMDemodulator.h
+++ b/scopeprotocols/OFDMDemodulator.h
@@ -35,7 +35,7 @@
 #ifndef OFDMDemodulator_h
 #define OFDMDemodulator_h
 
-#include <ffts/ffts.h>
+#include <ffts.h>
 
 class OFDMDemodulator : public Filter
 {


### PR DESCRIPTION
From how FindFFTS.cmake works, LIBFFTS_INCLUDE_DIR will already
include the ffts/ component.

Fixes #230

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>