### PR TITLE
Add specific define for MSYS2 mingw64 to support C *printf Format %z

### DIFF
--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -36,6 +36,8 @@
 #ifndef scopehal_h
 #define scopehal_h
 
+#define __USE_MINGW_ANSI_STDIO 1 // Required for MSYS2 mingw64 to support format "%z" ..
+
 #include <vector>
 #include <string>
 #include <map>


### PR DESCRIPTION
Add #define __USE_MINGW_ANSI_STDIO 1
Required for MSYS2 mingw64 to C *printf Format "%zu" ...
For more details see https://www.msys2.org/wiki/Porting chapter C *printf Format Specifier issues