### PR TITLE
Fix glscopeclient hangs on Rigol MSO5000

### DIFF
--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -789,7 +789,10 @@ bool RigolOscilloscope::AcquireData()
 			m_transport->SendCommand(":RUN");
 		}
 		else
+		{
 			m_transport->SendCommand(":SING");
+			m_transport->SendCommand("*WAI");
+		}
 		m_triggerArmed = true;
 	}
 
@@ -808,7 +811,10 @@ void RigolOscilloscope::Start()
 		m_transport->SendCommand(":RUN");
 	}
 	else
+	{
 		m_transport->SendCommand(":SING");
+		m_transport->SendCommand("*WAI");
+	}
 	m_triggerArmed = true;
 	m_triggerOneShot = false;
 }
@@ -822,7 +828,10 @@ void RigolOscilloscope::StartSingleTrigger()
 		m_transport->SendCommand(":RUN");
 	}
 	else
+	{
 		m_transport->SendCommand(":SING");
+		m_transport->SendCommand("*WAI");
+	}
 	m_triggerArmed = true;
 	m_triggerOneShot = true;
 }


### PR DESCRIPTION
Fix the issue https://github.com/azonenberg/scopehal/issues/358 "glscopeclient hangs on Rigol MSO5000"
This fix Rigol MSO5000 oscilloscope single trigger synchronization with waveform data by adding "*WAI" command which "Waits for all the pending operations to complete before executing any additional commands." (it is an IEEE488.2 Common Commands)