### PR TITLE
Compute next highest power of 2 function

### DIFF
--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -409,3 +409,18 @@ string to_string_sci(double d)
 	snprintf(tmp, sizeof(tmp), "%e", d);
 	return tmp;
 }
+
+/**
+	@brief compute the next highest power of 2 of 64-bit value
+ */
+uint64_t next_pow2(uint64_t v) 
+{
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+	v++;
+	return v;
+}


### PR DESCRIPTION
Compute next highest power of 2 to fix issues when using code (in different parts):
  const size_t npoints = pow(2, ceil(log2(depth))); (see scopehal\TestWaveformSource.cpp => TestWaveformSource::DegradeSerialData()...)
The original code (pow(2, ceil(log2())) has some border effects when built with MSYS2 mingw64 "Release" mode as it does not compute correctly the highest power of 2 for example with parameter 100000 it was returning 131071 (instead of 131072) which crashed ffts.
This implementation fix issue https://github.com/azonenberg/scopehal-apps/issues/295
The function next_pow2() shall replace pow(2, ceil(log2())) in following code:
scopehal\TestWaveformSource.cpp
	Line 282: 	//const size_t npoints = pow(2, ceil(log2(depth)));
scopeprotocols\DeEmbedFilter.cpp
	Line 230: 	const size_t npoints = pow(2, ceil(log2(npoints_raw)));
scopeprotocols\FFTFilter.cpp
	Line 179: 	const size_t npoints = pow(2, ceil(log2(npoints_raw)));
scopeprotocols\JitterSpectrumFilter.cpp
	Line 195: 	const size_t npoints = pow(2, ceil(log2(npoints_raw)));