### PR TITLE
Fix Demo (TestWaveformSource.cpp) crash issue with MSYS2 mingw64 Release build

### DIFF
--- a/scopehal/TestWaveformSource.cpp
+++ b/scopehal/TestWaveformSource.cpp
@@ -279,7 +279,7 @@ void TestWaveformSource::DegradeSerialData(AnalogWaveform* cap, int64_t samplepe
 	normal_distribution<> noise(0, 0.01);
 
 	//Prepare for second pass: reallocate FFT buffer if sample depth changed
-	const size_t npoints = pow(2, ceil(log2(depth)));
+	const size_t npoints = next_pow2(depth);
 	size_t nouts = npoints/2 + 1;
 	if(m_cachedNumPoints != npoints)
 	{


### PR DESCRIPTION
Compute next highest power of 2 to fix issues when using code (in different parts):
const size_t npoints = pow(2, ceil(log2(depth))); (see scopehal\TestWaveformSource.cpp => TestWaveformSource::DegradeSerialData()...)
The original code (pow(2, ceil(log2())) has some border effects when built with MSYS2 mingw64 "Release" mode as it does not compute correctly the highest power of 2 for example with parameter 100000 it was returning 131071 (instead of 131072) which crashed ffts.
This implementation fix issue azonenberg/scopehal-apps#295