### PR TITLE
Fix JitterSpectrumFilter.cpp crash issue with MSYS2 mingw64 Release b…

### DIFF
--- a/scopeprotocols/JitterSpectrumFilter.cpp
+++ b/scopeprotocols/JitterSpectrumFilter.cpp
@@ -192,7 +192,7 @@ void JitterSpectrumFilter::Refresh()
 
 	//Round size up to next power of two
 	const size_t npoints_raw = extended_samples.size();
-	const size_t npoints = pow(2, ceil(log2(npoints_raw)));
+	const size_t npoints = next_pow2(npoints_raw);
 	LogTrace("JitterSpectrumFilter: processing %zu raw points\n", npoints_raw);
 	LogTrace("Rounded to %zu\n", npoints);
 


### PR DESCRIPTION
…uild

Compute next highest power of 2 to fix issues when using code:
const size_t npoints = next_pow2(npoints_raw);
The original code (pow(2, ceil(log2())) has some border effects when built with MSYS2 mingw64 "Release" mode as it does not compute correctly the highest power of 2 for example with parameter 100000 it was returning 131071 (instead of 131072) which crashed ffts.
This implementation fix issue azonenberg/scopehal-apps#295