### PR TITLE
AgilentOscilloscope: request max points

### DIFF
--- a/scopehal/AgilentOscilloscope.cpp
+++ b/scopehal/AgilentOscilloscope.cpp
@@ -100,6 +100,7 @@ AgilentOscilloscope::AgilentOscilloscope(SCPITransport* transport)
 
 		//Request all points when we download
 		m_transport->SendCommand(":WAV:POIN:MODE RAW");
+		m_transport->SendCommand(":WAV:POIN 4000000");
 	}
 	m_analogChannelCount = nchans;
 


### PR DESCRIPTION
Previously, this would be left at some smaller default value and the
scope would downsample the displayed points to hit that number.

Instead, request all available points (but the scope will only return
what is displayed).