### PR TITLE
Add binary capture file parser

### DIFF
--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -565,9 +565,9 @@ bool MockOscilloscope::LoadBIN(const string& path)
 	LogDebug("Waveforms: %i\n\n", fh.count);
 
 	//Load waveforms
-	for(int i=0; i<fh.count; i++)
+	for(size_t i=0; i<fh.count; i++)
 	{
-		LogDebug("Waveform %i:\n", i+1);
+		LogDebug("Waveform %i:\n", (int)i+1);
 		LogIndenter li_w;
 
 		//Parse waveform header
@@ -638,9 +638,9 @@ bool MockOscilloscope::LoadBIN(const string& path)
 		//Loop through waveform buffers
 		float vmin = FLT_MAX;
 		float vmax = -FLT_MAX;
-		for(int j=0; j<wh.buffers; j++)
+		for(size_t j=0; j<wh.buffers; j++)
 		{
-			LogDebug("Buffer %i:\n", j+1);
+			LogDebug("Buffer %i:\n", (int)j+1);
 			LogIndenter li_b;
 
 			//Parse waveform data header
@@ -655,7 +655,7 @@ bool MockOscilloscope::LoadBIN(const string& path)
 			//Loop through waveform samples
 			float sample = 0;
 			uint8_t sample_i = 0;
-			for(int k=0; k<wh.samples; k++)
+			for(size_t k=0; k<wh.samples; k++)
 			{
 				if (dh.type == 6)
 				{

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -342,8 +342,80 @@ void MockOscilloscope::PullTrigger()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Import a waveform from CSV
+// Import a waveform from file
 
+/**
+	@brief Reads bytes from file into array and returns the array pointer
+ */
+char* MockOscilloscope::ReadFromFile(int len, FILE* fp)
+{
+	char* buf = new char[len + 1]();
+	fread(buf, 1, len, fp);
+
+	return buf;
+}
+
+/**
+	@brief Converts char array to integer
+ */
+int MockOscilloscope::BytesToInt(char* b, int len)
+{
+	int i = (uint8_t)b[0] | ((uint8_t)b[1] << 8);
+	if (len==4)
+		i |= ((uint8_t)b[2] << 16) | ((uint8_t)b[3] << 24);
+
+	return i;
+}
+
+/**
+	@brief Converts char array to float
+ */
+float MockOscilloscope::BytesToFloat(char* b)
+{
+	union
+	{
+		float f;
+		char b[4];
+	} u;
+
+	u.b[0] = b[0];
+	u.b[1] = b[1];
+	u.b[2] = b[2];
+	u.b[3] = b[3];
+
+	return u.f;
+
+	//FIXME: There's probably a better way to do this, but it works
+}
+
+/**
+	@brief Converts char array to double
+ */
+double MockOscilloscope::BytesToDouble(char* b)
+{
+	union
+	{
+		double d;
+		char b[8];
+	} u;
+
+	u.b[0] = b[0];
+	u.b[1] = b[1];
+	u.b[2] = b[2];
+	u.b[3] = b[3];
+	u.b[4] = b[4];
+	u.b[5] = b[5];
+	u.b[6] = b[6];
+	u.b[7] = b[7];
+
+	return u.d;
+
+	//FIXME: There's probably a better way to do this, but it works
+}
+
+/**
+	@brief Imports waveforms from Comma Separated Value files
+ */
 bool MockOscilloscope::LoadCSV(const string& path)
 {
 	LogTrace("Importing CSV file \"%s\"\n", path.c_str());
@@ -522,6 +594,190 @@ bool MockOscilloscope::LoadCSV(const string& path)
 		chan->SetVoltageRange(vmax - vmin);
 		chan->SetOffset((vmin-vmax) / 2);
 	}
+
+	return true;
+}
+
+/**
+	@brief Imports waveforms from Agilent/Keysight/Rigol binary capture files
+ */
+bool MockOscilloscope::LoadBIN(const string& path)
+{
+	LogTrace("Importing Agilent/Keysight/Rigol BIN file \"%s\"\n", path.c_str());
+	LogIndenter li_f;
+
+	//Open .bin file in binary mode
+	FILE* fp = fopen(path.c_str(), "rb");
+	if(!fp)
+	{
+		LogError("Failed to open file");
+		return false;
+	}
+
+	//Parse file header
+	FileHeader fh;
+	fh.magic = ReadFromFile(2, fp);						//File signature ("AG")
+	fh.version = ReadFromFile(2, fp);					//File format version
+	fh.length = BytesToInt(ReadFromFile(4, fp), 4);		//Length of file in bytes
+	fh.count = BytesToInt(ReadFromFile(4, fp), 4);		//Number of waveforms
+
+	//Check file signature
+	if(strcmp(fh.magic, "AG") != 0 && strcmp(fh.magic, "RG") != 0)
+	{
+		LogError("Unknown file format");
+		return false;
+	}
+
+	//LogDebug("File size: %i KB\n", fh.length / 1024);
+	//LogDebug("Waveforms: %i\n\n", (int)fh.count);
+
+	//Load waveforms
+	vector<AnalogWaveform*> waveforms;
+	for(size_t i=0; i<fh.count; i++)
+	{
+		LogDebug("Waveform %i:\n", (int)i+1);
+		LogIndenter li_w;
+
+		//Parse waveform header
+		WaveHeader wh;
+		wh.size = BytesToInt(ReadFromFile(4, fp), 4);		//Waveform header length (0x8C)
+		wh.type = BytesToInt(ReadFromFile(4, fp), 4);		//Waveform type
+		wh.buffers = BytesToInt(ReadFromFile(4, fp), 4);	//Number of buffers
+		wh.samples = BytesToInt(ReadFromFile(4, fp), 4);	//Number of samples
+		wh.averaging = BytesToInt(ReadFromFile(4, fp), 4);	//Averaging count
+		wh.duration = BytesToFloat(ReadFromFile(4, fp));	//Capture duration
+		wh.start = BytesToDouble(ReadFromFile(8, fp));		//Display start time
+		wh.interval = BytesToDouble(ReadFromFile(8, fp));	//Sample time interval
+		wh.origin = BytesToDouble(ReadFromFile(8, fp));		//Capture origin time
+		wh.x = BytesToInt(ReadFromFile(4, fp), 4);			//X axis unit
+		wh.y = BytesToInt(ReadFromFile(4, fp), 4);			//Y axis unit
+		wh.date = ReadFromFile(16, fp);						//Capture date
+		wh.time = ReadFromFile(16, fp);						//Capture time
+		char* hardware = ReadFromFile(24, fp);				//Hardware string (model + serial)
+		wh.label = ReadFromFile(16, fp);					//Waveform label	
+		wh.holdoff = BytesToDouble(ReadFromFile(8, fp));	//Trigger holdoff
+		wh.segment = BytesToInt(ReadFromFile(4, fp), 4);	//Segment number
+		wh.rate = (uint64_t)(1 / wh.interval);				//Calculated sample rate
+
+		// Split hardware string
+		int idx = 0;
+		for(int c=0; c<24; c++)
+		{
+			if(hardware[c] == ':')
+			{
+				idx = c;
+				break;
+			}
+		}
+
+		//Frame model
+		wh.frame = new char[idx + 1]();
+		strncpy(wh.frame, hardware, idx);
+
+		//Frame serial
+		wh.serial = new char[24 - idx]();
+		strncpy(wh.serial, hardware + idx + 1, 24 - idx - 1);
+
+		//Log waveform info
+		LogDebug("Samples:      %i\n", (int)wh.samples);
+		LogDebug("Buffers:      %i\n", (int)wh.buffers);
+		LogDebug("Type:         %i\n", wh.type);
+		LogDebug("Duration:     %.*f us\n", 2, wh.duration * 1e6);
+		LogDebug("Start:        %.*f us\n", 2, wh.start * 1e6);
+		LogDebug("Interval:     %.*f ns\n", 2, wh.interval * 1e9);
+		LogDebug("Origin:       %.*f us\n", 2, wh.origin * 1e6);
+		LogDebug("Holdoff:      %.*f ms\n", 2, wh.holdoff * 1e3);
+		LogDebug("Sample Rate:  %.*f Msps\n", 2, wh.rate / 1e6);
+		LogDebug("Frame:        %s\n", wh.frame);
+		LogDebug("Serial:       %s\n\n", wh.serial);
+
+		//Set oscilloscope metadata
+		m_vendor = "Agilent/Keysight/Rigol";
+		m_name = wh.frame;
+		m_serial = wh.serial;
+
+		// Create new channel
+		auto chan = new OscilloscopeChannel(
+			this,			//Parent scope
+			wh.label,		//Channel name
+			OscilloscopeChannel::CHANNEL_TYPE_ANALOG,
+			GetDefaultChannelColor(i),
+			units[wh.x],
+			units[wh.y],
+			1,				//Bus width
+			i,				//Channel index
+			true			//Is physical channel
+		);
+		AddChannel(chan);
+		chan->SetDefaultDisplayName();
+
+		//Create new waveform for channel
+		auto wfm = new AnalogWaveform;
+		wfm->m_timescale = wh.interval * 1e15;
+		wfm->m_startTimestamp = 0;
+		wfm->m_startFemtoseconds = 0;
+		wfm->m_triggerPhase = 0;
+		waveforms.push_back(wfm);
+		chan->SetData(wfm, 0);
+
+		//Loop through waveform buffers
+		auto w = waveforms[i];
+		float vmin = FLT_MAX;
+		float vmax = -FLT_MAX;
+		for(size_t j=0; j<wh.buffers; j++)
+		{
+			LogDebug("Buffer %i:\n", (int)j+1);
+			LogIndenter li_b;
+
+			//Parse waveform data header
+			DataHeader dh;
+			dh.size = BytesToInt(ReadFromFile(4, fp), 4);		//Waveform data header length
+			dh.type = BytesToInt(ReadFromFile(2, fp), 2);		//Sample data type
+			dh.depth = BytesToInt(ReadFromFile(2, fp), 2) * 8;	//Sample bit depth
+			dh.length = BytesToInt(ReadFromFile(4, fp), 4);		//Data buffer length
+
+    		LogDebug("Data Type:      %i\n", dh.type);
+    		LogDebug("Sample depth:   %i bits\n", dh.depth);
+    		LogDebug("Buffer length:  %i KB\n\n\n", dh.length / 1024);
+
+			//Loop through waveform samples
+			for(size_t k=0; k<wh.samples; k++)
+			{
+				//Handle different data types
+				float sample;
+				if(dh.type == 6 && dh.depth == 8)
+				{
+					//8-bit integer samples
+					uint8_t sample_i = (int)ReadFromFile(1, fp)[0];
+					sample = (float)sample_i;
+				}
+				else if(dh.type == 6 && dh.depth == 16)
+				{
+					//16-bit integer samples
+					uint16_t sample_i = BytesToInt(ReadFromFile(2, fp), 2);
+					sample = (float)sample_i;
+				}
+				else
+				{
+					//32-bit float samples
+					sample = BytesToFloat(ReadFromFile(4, fp));
+				}
+
+				w->m_offsets.push_back(k);
+				w->m_samples.push_back(sample);
+				w->m_durations.push_back(1);
+
+				vmax = max(vmax, sample);
+				vmin = min(vmin, sample);
+			}
+		}
+
+		//Calculate offset and range
+		chan->SetVoltageRange((vmax-vmin) * 1.5);
+		chan->SetOffset(-((vmax-abs(vmin)) / 2));
+	}
+
+	fclose(fp);
 
 	return true;
 }

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -654,19 +654,19 @@ bool MockOscilloscope::LoadBIN(const string& path)
 
 			//Loop through waveform samples
 			float sample = 0;
-			int sample_i = 0;
+			uint8_t sample_i = 0;
 			for(int k=0; k<wh.samples; k++)
 			{
 				if (dh.type == 6)
 				{
 					//Integer samples (digital waveforms)
-					memcpy(&sample_i, f.c_str() + fpos, dh.depth);
+					memcpy(&sample_i, f.c_str() + fpos, 1);
 					sample = (float)sample_i;
 				}
 				else
 				{
 					//Float samples (analog waveforms)
-					memcpy(&sample, f.c_str() + fpos, dh.depth);
+					memcpy(&sample, f.c_str() + fpos, 4);
 				}
 				fpos += dh.depth;
 

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -538,7 +538,7 @@ bool MockOscilloscope::LoadBIN(const string& path)
 	LogIndenter li_f;
 
 	string f = ReadFile(path);
-	unsigned int fpos = 0;
+	uint32_t fpos = 0;
 
 	FileHeader fh;
 	f.copy((char*)&fh, sizeof(FileHeader), fpos);
@@ -647,22 +647,23 @@ bool MockOscilloscope::LoadBIN(const string& path)
     		LogDebug("Buffer length:  %i KB\n\n\n", dh.length/1024);
 
 			//Loop through waveform samples
+			float* sample_f = nullptr;
+			uint8_t* sample_i = nullptr;
 			float sample = 0;
-			uint8_t sample_i = 0;
 			for(size_t k=0; k<wh.samples; k++)
 			{
 				if (dh.type == 6)
 				{
 					//Integer samples (digital waveforms)
-					memcpy(&sample_i, f.c_str() + fpos, 1);
-					sample = (float)sample_i;
+					sample_i = (uint8_t*)(f.c_str() + fpos);
+					sample = (float)*sample_i;
 				}
 				else
 				{
 					//Float samples (analog waveforms)
-					memcpy(&sample, f.c_str() + fpos, 4);
+					sample_f = (float*)(f.c_str() + fpos);
+					sample = *sample_f;
 				}
-				fpos += dh.depth;
 
 				//Push sample to waveform
 				wfm->m_offsets.push_back(k);
@@ -672,6 +673,8 @@ bool MockOscilloscope::LoadBIN(const string& path)
 				//Update voltage min/max values
 				vmax = max(vmax, sample);
 				vmin = min(vmin, sample);
+
+				fpos += dh.depth;
 			}
 		}
 

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -603,7 +603,7 @@ bool MockOscilloscope::LoadCSV(const string& path)
  */
 bool MockOscilloscope::LoadBIN(const string& path)
 {
-	LogTrace("Importing Agilent/Keysight/Rigol BIN file \"%s\"\n", path.c_str());
+	LogTrace("Importing BIN file \"%s\"\n", path.c_str());
 	LogIndenter li_f;
 
 	//Open .bin file in binary mode
@@ -622,12 +622,22 @@ bool MockOscilloscope::LoadBIN(const string& path)
 	fh.count = BytesToInt(ReadFromFile(4, fp), 4);		//Number of waveforms
 
 	//Check file signature
-	if(strcmp(fh.magic, "AG") != 0 && strcmp(fh.magic, "RG") != 0)
+	switch(fh.magic[0])
 	{
-		LogError("Unknown file format");
-		return false;
-	}
+		case 'A':	//"AG"
+			m_vendor = "Agilent/Keysight";
+			break;
 
+		case 'R':	//"RG"
+			m_vendor = "Rigol";
+			break;
+
+		default:
+			LogError("Unknown file format");
+			return false;
+	}
+	
+	LogDebug("Vendor: %s\n\n", m_vendor.c_str());
 	//LogDebug("File size: %i KB\n", fh.length / 1024);
 	//LogDebug("Waveforms: %i\n\n", (int)fh.count);
 
@@ -692,7 +702,6 @@ bool MockOscilloscope::LoadBIN(const string& path)
 		LogDebug("Serial:       %s\n\n", wh.serial);
 
 		//Set oscilloscope metadata
-		m_vendor = "Agilent/Keysight/Rigol";
 		m_name = wh.frame;
 		m_serial = wh.serial;
 

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -575,24 +575,28 @@ bool MockOscilloscope::LoadBIN(const string& path)
 		f.copy((char*)&wh, sizeof(WaveHeader), fpos);
 		fpos += sizeof(WaveHeader);
 
-		// Split hardware string
-		int idx = 0;
-		for(int c=0; c<24; c++)
+		// Only set name/serial on first waveform
+		if (i == 0)
 		{
-			if(wh.hardware[c] == ':')
+			// Split hardware string
+			int idx = 0;
+			for(int c=0; c<24; c++)
 			{
-				idx = c;
-				break;
+				if(wh.hardware[c] == ':')
+				{
+					idx = c;
+					break;
+				}
 			}
-		}
 
-		//Set oscilloscope metadata
-		char* name = new char[idx]();
-		char* serial = new char[24-idx]();
-		strncpy(name, wh.hardware, idx);
-		strncpy(serial, wh.hardware + idx + 1, 24 - idx - 1);
-		m_name = name;
-		m_serial = serial;
+			//Set oscilloscope metadata
+			char* name = new char[idx]();
+			char* serial = new char[24-idx]();
+			strncpy(name, wh.hardware, idx);
+			strncpy(serial, wh.hardware + idx + 1, 24 - idx - 1);
+			m_name = name;
+			m_serial = serial;
+		}
 
 		LogDebug("Samples:      %i\n", wh.samples);
 		LogDebug("Buffers:      %i\n", wh.buffers);

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -653,8 +653,8 @@ bool MockOscilloscope::LoadBIN(const string& path)
     		LogDebug("Buffer length:  %i KB\n\n\n", dh.length/1024);
 
 			//Loop through waveform samples
-			float sample;
-			int sample_i;
+			float sample = 0;
+			int sample_i = 0;
 			for(int k=0; k<wh.samples; k++)
 			{
 				if (dh.type == 6)

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -590,14 +590,8 @@ bool MockOscilloscope::LoadBIN(const string& path)
 			}
 
 			//Set oscilloscope metadata
-			char* name = new char[idx]();
-			char* serial = new char[24-idx]();
-			strncpy(name, wh.hardware, idx);
-			strncpy(serial, wh.hardware + idx + 1, 24 - idx - 1);
-			m_name = name;
-			m_serial = serial;
-			delete[] name;
-			delete[] serial;
+			m_name.assign(wh.hardware, idx);
+			m_serial.assign(wh.hardware + idx + 1, 24 - idx);
 		}
 
 		LogDebug("Samples:      %i\n", wh.samples);

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -565,7 +565,6 @@ bool MockOscilloscope::LoadBIN(const string& path)
 	LogDebug("Waveforms: %i\n\n", fh->count);
 
 	//Load waveforms
-	vector<AnalogWaveform*> waveforms;
 	for(int i=0; i<fh->count; i++)
 	{
 		LogDebug("Waveform %i:\n", i+1);
@@ -628,11 +627,9 @@ bool MockOscilloscope::LoadBIN(const string& path)
 		wfm->m_startTimestamp = 0;
 		wfm->m_startFemtoseconds = 0;
 		wfm->m_triggerPhase = 0;
-		waveforms.push_back(wfm);
 		chan->SetData(wfm, 0);
 
 		//Loop through waveform buffers
-		auto w = waveforms[i];
 		float vmin = FLT_MAX;
 		float vmax = -FLT_MAX;
 		for(int j=0; j<wh->buffers; j++)
@@ -668,9 +665,9 @@ bool MockOscilloscope::LoadBIN(const string& path)
 				fpos += dh->depth;
 
 				//Push sample to waveform
-				w->m_offsets.push_back(k);
-				w->m_samples.push_back(sample);
-				w->m_durations.push_back(1);
+				wfm->m_offsets.push_back(k);
+				wfm->m_samples.push_back(sample);
+				wfm->m_durations.push_back(1);
 
 				//Update voltage min/max values
 				vmax = max(vmax, sample);

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -596,6 +596,8 @@ bool MockOscilloscope::LoadBIN(const string& path)
 			strncpy(serial, wh.hardware + idx + 1, 24 - idx - 1);
 			m_name = name;
 			m_serial = serial;
+			delete[] name;
+			delete[] serial;
 		}
 
 		LogDebug("Samples:      %i\n", wh.samples);

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -647,34 +647,48 @@ bool MockOscilloscope::LoadBIN(const string& path)
     		LogDebug("Buffer length:  %i KB\n\n\n", dh.length/1024);
 
 			//Loop through waveform samples
-			float* sample_f = nullptr;
-			uint8_t* sample_i = nullptr;
 			float sample = 0;
-			for(size_t k=0; k<wh.samples; k++)
+			if (dh.type == 6)
 			{
-				if (dh.type == 6)
+				//Integer samples (digital waveforms)
+				uint8_t* sample_i = nullptr;
+				for(size_t k=0; k<wh.samples; k++)
 				{
-					//Integer samples (digital waveforms)
 					sample_i = (uint8_t*)(f.c_str() + fpos);
 					sample = (float)*sample_i;
+
+					//Push sample to waveform
+					wfm->m_offsets.push_back(k);
+					wfm->m_samples.push_back(sample);
+					wfm->m_durations.push_back(1);
+
+					//Update voltage min/max values
+					vmax = max(vmax, sample);
+					vmin = min(vmin, sample);
+
+					fpos += dh.depth;
 				}
-				else
+			}
+			else
+			{
+				//Float samples (analog waveforms)
+				float* sample_f = nullptr;
+				for(size_t k=0; k<wh.samples; k++)
 				{
-					//Float samples (analog waveforms)
 					sample_f = (float*)(f.c_str() + fpos);
 					sample = *sample_f;
+
+					//Push sample to waveform
+					wfm->m_offsets.push_back(k);
+					wfm->m_samples.push_back(sample);
+					wfm->m_durations.push_back(1);
+
+					//Update voltage min/max values
+					vmax = max(vmax, sample);
+					vmin = min(vmin, sample);
+
+					fpos += dh.depth;
 				}
-
-				//Push sample to waveform
-				wfm->m_offsets.push_back(k);
-				wfm->m_samples.push_back(sample);
-				wfm->m_durations.push_back(1);
-
-				//Update voltage min/max values
-				vmax = max(vmax, sample);
-				vmin = min(vmin, sample);
-
-				fpos += dh.depth;
 			}
 		}
 

--- a/scopehal/MockOscilloscope.h
+++ b/scopehal/MockOscilloscope.h
@@ -42,7 +42,61 @@ public:
 	MockOscilloscope(const std::string& name, const std::string& vendor, const std::string& serial);
 	virtual ~MockOscilloscope();
 
+	//Capture file importing
+	char* ReadFromFile(int len, FILE* fp);
+	short BytesToShort(char* b);
+	int BytesToInt(char* b, int len);
+	float BytesToFloat(char* b);
+	double BytesToDouble(char* b);
 	bool LoadCSV(const std::string& path);
+	bool LoadBIN(const std::string& path);
+
+	//Agilent/Keysight/Rigol binary capture structs
+	struct FileHeader
+	{
+		char* magic;		//File magic string ("AG" / "RG")
+		char* version;		//File format version
+		int length;			//Length of file in bytes
+		size_t count;		//Number of waveforms
+	};
+	struct WaveHeader
+	{
+		int size;			//Waveform header length (0x8C)
+		int type;			//Waveform type
+		size_t buffers;		//Number of buffers
+		size_t samples;		//Number of samples
+		int averaging;		//Averaging count
+		float duration;		//Capture duration
+		double start;		//Display start time
+		double interval;	//Sample time interval
+		double origin;		//Capture origin time
+		int x;				//X axis unit
+		int y;				//Y axis unit
+		char* date;			//Capture date
+		char* time;			//Capture time
+		char* frame;		//Frame model
+		char* serial;		//Frame serial
+		char* label;		//Waveform label
+		double holdoff;		//Trigger holdoff
+		int segment;		//Segment number
+		uint64_t rate;		//Sample rate
+	};
+	struct DataHeader
+	{
+		int size;			//Waveform data header length
+		int type;			//Sample data type
+		int depth;			//Sample bit depth
+		int length;			//Data buffer length
+	};
+	Unit::UnitType units[7] = {
+		Unit::UNIT_COUNTS,	//Unused
+		Unit::UNIT_VOLTS,
+		Unit::UNIT_FS,
+		Unit::UNIT_COUNTS,	//"Constant"
+		Unit::UNIT_AMPS,
+		Unit::UNIT_DB,
+		Unit::UNIT_HZ
+	};
 
 	//not copyable or assignable
 	MockOscilloscope(const MockOscilloscope& rhs) =delete;
@@ -129,4 +183,3 @@ public:
 };
 
 #endif
-

--- a/scopehal/MockOscilloscope.h
+++ b/scopehal/MockOscilloscope.h
@@ -52,39 +52,39 @@ public:
 	{
 		char magic[2];		//File magic string ("AG" / "RG")
 		char version[2];	//File format version
-		int length;			//Length of file in bytes
-		int count;			//Number of waveforms
+		uint32_t length;	//Length of file in bytes
+		uint32_t count;		//Number of waveforms
 	};
 
 	#pragma pack(1)
 	struct WaveHeader
 	{
-		int size;			//Waveform header length (0x8C)
-		int type;			//Waveform type
-		int buffers;		//Number of buffers
-		int samples;		//Number of samples
-		int averaging;		//Averaging count
+		uint32_t size;		//Waveform header length (0x8C)
+		uint32_t type;		//Waveform type
+		uint32_t buffers;	//Number of buffers
+		uint32_t samples;	//Number of samples
+		uint32_t averaging;	//Averaging count
 		float duration;		//Capture duration
 		double start;		//Display start time
 		double interval;	//Sample time interval
 		double origin;		//Capture origin time
-		int x;				//X axis unit
-		int y;				//Y axis unit
+		uint32_t x;			//X axis unit
+		uint32_t y;			//Y axis unit
 		char date[16];		//Capture date
 		char time[16];		//Capture time
 		char hardware[24];	//Model and serial
 		char label[16];		//Waveform label
 		double holdoff;		//Trigger holdoff
-		int segment;		//Segment number
+		uint32_t segment;	//Segment number
 	};
 
 	#pragma pack(1)
 	struct DataHeader
 	{
-		int size;			//Waveform data header length
+		uint32_t size;		//Waveform data header length
 		short type;			//Sample data type
 		short depth;		//Sample bit depth
-		int length;			//Data buffer length
+		uint32_t length;	//Data buffer length
 	};
 
 	Unit::UnitType units[7] = {

--- a/scopehal/MockOscilloscope.h
+++ b/scopehal/MockOscilloscope.h
@@ -52,19 +52,22 @@ public:
 	bool LoadBIN(const std::string& path);
 
 	//Agilent/Keysight/Rigol binary capture structs
+	#pragma pack(1)
 	struct FileHeader
 	{
-		char* magic;		//File magic string ("AG" / "RG")
-		char* version;		//File format version
+		char magic[2];		//File magic string ("AG" / "RG")
+		char version[2];	//File format version
 		int length;			//Length of file in bytes
-		size_t count;		//Number of waveforms
+		int count;			//Number of waveforms
 	};
+
+	#pragma pack(1)
 	struct WaveHeader
 	{
 		int size;			//Waveform header length (0x8C)
 		int type;			//Waveform type
-		size_t buffers;		//Number of buffers
-		size_t samples;		//Number of samples
+		int buffers;		//Number of buffers
+		int samples;		//Number of samples
 		int averaging;		//Averaging count
 		float duration;		//Capture duration
 		double start;		//Display start time
@@ -72,22 +75,23 @@ public:
 		double origin;		//Capture origin time
 		int x;				//X axis unit
 		int y;				//Y axis unit
-		char* date;			//Capture date
-		char* time;			//Capture time
-		char* frame;		//Frame model
-		char* serial;		//Frame serial
-		char* label;		//Waveform label
+		char date[16];		//Capture date
+		char time[16];		//Capture time
+		char hardware[24];	//Model and serial
+		char label[16];		//Waveform label
 		double holdoff;		//Trigger holdoff
 		int segment;		//Segment number
-		uint64_t rate;		//Sample rate
 	};
+
+	#pragma pack(1)
 	struct DataHeader
 	{
 		int size;			//Waveform data header length
-		int type;			//Sample data type
-		int depth;			//Sample bit depth
+		short type;			//Sample data type
+		short depth;		//Sample bit depth
 		int length;			//Data buffer length
 	};
+
 	Unit::UnitType units[7] = {
 		Unit::UNIT_COUNTS,	//Unused
 		Unit::UNIT_VOLTS,

--- a/scopehal/MockOscilloscope.h
+++ b/scopehal/MockOscilloscope.h
@@ -47,7 +47,7 @@ public:
 	bool LoadBIN(const std::string& path);
 
 	//Agilent/Keysight/Rigol binary capture structs
-	#pragma pack(1)
+	#pragma pack(push, 1)
 	struct FileHeader
 	{
 		char magic[2];		//File magic string ("AG" / "RG")
@@ -56,7 +56,6 @@ public:
 		uint32_t count;		//Number of waveforms
 	};
 
-	#pragma pack(1)
 	struct WaveHeader
 	{
 		uint32_t size;		//Waveform header length (0x8C)
@@ -78,7 +77,6 @@ public:
 		uint32_t segment;	//Segment number
 	};
 
-	#pragma pack(1)
 	struct DataHeader
 	{
 		uint32_t size;		//Waveform data header length
@@ -86,6 +84,7 @@ public:
 		short depth;		//Sample bit depth
 		uint32_t length;	//Data buffer length
 	};
+	#pragma pack(pop)
 
 	Unit::UnitType units[7] = {
 		Unit::UNIT_COUNTS,	//Unused

--- a/scopehal/MockOscilloscope.h
+++ b/scopehal/MockOscilloscope.h
@@ -43,11 +43,6 @@ public:
 	virtual ~MockOscilloscope();
 
 	//Capture file importing
-	char* ReadFromFile(int len, FILE* fp);
-	short BytesToShort(char* b);
-	int BytesToInt(char* b, int len);
-	float BytesToFloat(char* b);
-	double BytesToDouble(char* b);
 	bool LoadCSV(const std::string& path);
 	bool LoadBIN(const std::string& path);
 

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -624,7 +624,7 @@ string ReadFile(const string& path)
 	buf[fsize] = 0;
 	fclose(fp);
 
-	string ret(buf);
+	string ret(buf, fsize);
 	delete[] buf;
 
 	return ret;


### PR DESCRIPTION
This PR adds a parser for Agilent, Keysight and Rigol multi-channel binary waveform capture files.

I've added helper functions `ReadFromFile()`, `BytesToInt()`, `BytesToFloat()` and `BytesToDouble()` to make parsing the file headers easier. I don't write C++ code all that often so let me know if there's a better way to do this.

See related PR azonenberg/scopehal-apps#307 for changes to Import dialog.