### PR TITLE
Add cache to COUP on RS scopes, fix wrong COUP response

### DIFF
--- a/scopehal/RohdeSchwarzOscilloscope.h
+++ b/scopehal/RohdeSchwarzOscilloscope.h
@@ -102,6 +102,7 @@ protected:
 	std::map<size_t, double> m_channelOffsets;
 	std::map<size_t, double> m_channelVoltageRanges;
 	std::map<int, bool> m_channelsEnabled;
+	std::map<size_t, OscilloscopeChannel::CouplingType> m_channelCouplings;
 
 	bool m_triggerArmed;
 	bool m_triggerOneShot;


### PR DESCRIPTION
This PR adds cache to the COUP query for RS scopes.
Additionally, on RTM3000, actual response is "DCL" or "ACL", added that condition also.
