### PR TITLE
add . to the search path for locals builds that dont have readlink

### DIFF
--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -666,6 +666,7 @@ void InitializeSearchPaths()
 	//Local directories preferred over system ones
 #ifndef _WIN32
 	string home = getenv("HOME");
+	g_searchPaths.push_back(".");
 	g_searchPaths.push_back(home + "/.glscopeclient");
 	g_searchPaths.push_back(home + "/.scopehal");
 	g_searchPaths.push_back("/usr/local/share/glscopeclient");


### PR DESCRIPTION
bsd doesn't have readlink unless the /proc filesystem is enabled, adding the search path of . allowed glscopeclient to find the shaders when it is run as ./glscopeclient however may lead to complications if it finds suitable files in the users current working directory