### PR TITLE
Changes as a result of testing Siglent Triggering modes

### DIFF
--- a/scopehal/DropoutTrigger.cpp
+++ b/scopehal/DropoutTrigger.cpp
@@ -31,14 +31,14 @@
 #include "DropoutTrigger.h"
 #include "LeCroyOscilloscope.h"
 #include "TektronixOscilloscope.h"
+#include "SiglentSCPIOscilloscope.h"
 
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Construction / destruction
 
-DropoutTrigger::DropoutTrigger(Oscilloscope* scope)
-	: Trigger(scope)
+DropoutTrigger::DropoutTrigger(Oscilloscope* scope) : Trigger(scope)
 {
 	CreateInput("din");
 
@@ -53,7 +53,7 @@ DropoutTrigger::DropoutTrigger(Oscilloscope* scope)
 	m_parameters[m_timename] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_FS));
 
 	m_resetname = "Reset Mode";
-	if(dynamic_cast<LeCroyOscilloscope*>(scope))
+	if((dynamic_cast<LeCroyOscilloscope*>(scope)) || (dynamic_cast<SiglentSCPIOscilloscope*>(scope)))
 	{
 		m_parameters[m_resetname] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
 		m_parameters[m_resetname].AddEnumValue("Opposite Edge", RESET_OPPOSITE);
@@ -63,7 +63,6 @@ DropoutTrigger::DropoutTrigger(Oscilloscope* scope)
 
 DropoutTrigger::~DropoutTrigger()
 {
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scopehal/PulseWidthTrigger.cpp
+++ b/scopehal/PulseWidthTrigger.cpp
@@ -31,6 +31,7 @@
 #include "PulseWidthTrigger.h"
 #include "LeCroyOscilloscope.h"
 #include "TektronixOscilloscope.h"
+#include "SiglentSCPIOscilloscope.h"
 
 using namespace std;
 
@@ -38,10 +39,7 @@ using namespace std;
 // Construction / destruction
 
 PulseWidthTrigger::PulseWidthTrigger(Oscilloscope* scope)
-	: EdgeTrigger(scope)
-	, m_conditionname("Condition")
-	, m_lowername("Lower Bound")
-	, m_uppername("Upper Bound")
+	: EdgeTrigger(scope), m_conditionname("Condition"), m_lowername("Lower Bound"), m_uppername("Upper Bound")
 {
 	m_parameters[m_lowername] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_FS));
 
@@ -53,7 +51,7 @@ PulseWidthTrigger::PulseWidthTrigger(Oscilloscope* scope)
 	m_parameters[m_conditionname].AddEnumValue("Between", CONDITION_BETWEEN);
 
 	//Some modes are only supported by certain vendors
-	if(dynamic_cast<LeCroyOscilloscope*>(scope) != NULL)
+	if((dynamic_cast<LeCroyOscilloscope*>(scope) != NULL) || (dynamic_cast<SiglentSCPIOscilloscope*>(scope) != NULL))
 		m_parameters[m_conditionname].AddEnumValue("Not between", CONDITION_NOT_BETWEEN);
 	if(dynamic_cast<TektronixOscilloscope*>(scope) != NULL)
 	{
@@ -65,7 +63,6 @@ PulseWidthTrigger::PulseWidthTrigger(Oscilloscope* scope)
 
 PulseWidthTrigger::~PulseWidthTrigger()
 {
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scopehal/RuntTrigger.cpp
+++ b/scopehal/RuntTrigger.cpp
@@ -31,6 +31,7 @@
 #include "RuntTrigger.h"
 #include "LeCroyOscilloscope.h"
 #include "TektronixOscilloscope.h"
+#include "SiglentSCPIOscilloscope.h"
 
 using namespace std;
 
@@ -56,8 +57,8 @@ RuntTrigger::RuntTrigger(Oscilloscope* scope)
 	m_parameters[m_slopename].AddEnumValue("Rising", EDGE_RISING);
 	m_parameters[m_slopename].AddEnumValue("Falling", EDGE_FALLING);
 
-	//LeCroy scopes support both min and max limits, so we can specify range operators
-	if(dynamic_cast<LeCroyOscilloscope*>(scope))
+	//LeCroy and Siglent scopes support both min and max limits, so we can specify range operators
+	if((dynamic_cast<LeCroyOscilloscope*>(scope)) || (dynamic_cast<SiglentSCPIOscilloscope*>(scope)))
 	{
 		m_parameters[m_upperintname] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_FS));
 
@@ -83,7 +84,6 @@ RuntTrigger::RuntTrigger(Oscilloscope* scope)
 
 RuntTrigger::~RuntTrigger()
 {
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -112,8 +112,8 @@ bool RuntTrigger::ValidateChannel(size_t i, StreamDescriptor stream)
 		return false;
 
 	//It has to be analog or external trigger, digital inputs make no sense
-	if( (stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_ANALOG) &&
-		(stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_TRIGGER) )
+	if((stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_ANALOG) &&
+		(stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_TRIGGER))
 	{
 		return false;
 	}

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -31,6 +31,7 @@
 #define SiglentSCPIOscilloscope_h
 
 #include <mutex>
+#include <chrono>
 
 class DropoutTrigger;
 class EdgeTrigger;
@@ -75,6 +76,7 @@ protected:
 	virtual void DetectAnalogChannels();
 	void AddDigitalChannels(unsigned int count);
 	void DetectOptions();
+	std::chrono::system_clock::time_point next_tx;
 
 public:
 	//Device information

--- a/scopehal/SlewRateTrigger.cpp
+++ b/scopehal/SlewRateTrigger.cpp
@@ -31,6 +31,7 @@
 #include "SlewRateTrigger.h"
 #include "LeCroyOscilloscope.h"
 #include "TektronixOscilloscope.h"
+#include "SiglentSCPIOscilloscope.h"
 
 using namespace std;
 
@@ -55,7 +56,7 @@ SlewRateTrigger::SlewRateTrigger(Oscilloscope* scope)
 	m_parameters[m_slopename].AddEnumValue("Falling", EDGE_FALLING);
 
 	//Make/model specific options
-	if(dynamic_cast<LeCroyOscilloscope*>(scope) != NULL)
+	if((dynamic_cast<LeCroyOscilloscope*>(scope) != NULL) || (dynamic_cast<SiglentSCPIOscilloscope*>(scope) != NULL))
 	{
 		m_parameters[m_conditionname].AddEnumValue("Between", CONDITION_BETWEEN);
 		m_parameters[m_conditionname].AddEnumValue("Not between", CONDITION_NOT_BETWEEN);
@@ -80,7 +81,6 @@ SlewRateTrigger::SlewRateTrigger(Oscilloscope* scope)
 
 SlewRateTrigger::~SlewRateTrigger()
 {
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -109,8 +109,8 @@ bool SlewRateTrigger::ValidateChannel(size_t i, StreamDescriptor stream)
 		return false;
 
 	//It has to be analog or external trigger, digital inputs make no sense
-	if( (stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_ANALOG) &&
-		(stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_TRIGGER) )
+	if((stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_ANALOG) &&
+		(stream.m_channel->GetType() != OscilloscopeChannel::CHANNEL_TYPE_TRIGGER))
 	{
 		return false;
 	}


### PR DESCRIPTION
Run through of all implemented triggering modes making sure they correspond to scope behaviours.
AFAIK they're all working fine now except RUNT triggers cannot set HLEVEL and LLEVELs...they both get the same value. Will send a bug request to Siglent.
There's no digital channels in here 'cos we still don't have the adapter yet.
As far as I'm concerned this can move from Alpha to Beta status now. It's functionally complete, but needs field test.