### PR TITLE
Add additional search paths used on Guix

### DIFF
--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -675,7 +675,12 @@ void InitializeSearchPaths()
 	else if ( (unsigned) readlinkReturn > (sizeof(binDir) - 1) )
 		LogError("Error: readlink() returned a path larger than our buffer.\n");
 	else
+	{
 		g_searchPaths.push_back(dirname(binDir));
+		string binRootDir = dirname(binDir);
+		g_searchPaths.push_back(binRootDir + "/share/glscopeclient");
+		g_searchPaths.push_back(binRootDir + "/share/scopehal");
+	}
 #endif
 
 	//Local directories preferred over system ones


### PR DESCRIPTION
Guix installs each package to a seperate folder under `/gnu/store/<hash>-<packagename>-<version>` (similar to Nix / NixOS).

By default the produces a tree like this:
```
/gnu/store/pxgpg9kagg7gbs8dijgr40lvb7wicvhg-glscopeclient-0.0-0e57974d7
├── bin
│  └── glscopeclient
└── share
   └── glscopeclient
      ├── gradients
      │  └── [...]
      ├── icons
      │  └── [...]
      ├── kernels
      │  └── [...]
      ├── shaders
      │  └── [...]
      └── styles
         └── [...]
```

So this adds the search paths necessary on such a platform.