### PR TITLE
[WIP] Fix LeCroy WaveSurfer 3k

### DIFF
--- a/scopehal/LeCroyOscilloscope.cpp
+++ b/scopehal/LeCroyOscilloscope.cpp
@@ -3364,6 +3364,13 @@ vector<uint64_t> LeCroyOscilloscope::GetSampleRatesNonInterleaved()
 					ret.push_back(20 * g);
 				break;
 
+			case MODEL_WAVESURFER_3K:
+				ret.push_back(200 * m);
+				ret.push_back(500 * m);
+				ret.push_back(1 * g);
+				ret.push_back(2 * g);
+				break;
+
 			default:
 				break;
 		}


### PR DESCRIPTION
Attempt to fix the support WaveSurfer 3k serie of scope.

Initially reported in #996 (and then partially reported in #1026 and #1028).

Most annoying issue is fixed in the current state : averaging is not present per channel but under `app.Acquisition.Horizontal.AverageSweeps`. For now I have naively updated this path for the WS3k, but I suppose that this might cause issues if ngscopeclient expect an average setting per channel. Seems to work tho, but eager to implement a nicer fix once all the discrepencies with other LeCroy will be identified.

Probe detection seems fixed, it was caused by abscence of probe mux being reported in differently than in other LeCroy scope: no .ActiveProbe property (and a differentt property for probe name).

Sample rate cannot be set dirrectly on these scope, so configuration is set by adjusting the horizontal scale.

Still investingating:
- Some combination of sample rate and memory depth are not working properly: the scope and app report different values
