### PR TITLE
R&S RTB2000 oscilloscope driver - USBTMC ‘ReadRawData()’

### DIFF
--- a/scopehal/SCPITMCTransport.cpp
+++ b/scopehal/SCPITMCTransport.cpp
@@ -233,7 +233,6 @@ size_t SCPITMCTransport::ReadRawData(size_t len, unsigned char* buf, std::functi
 
 			if (m_data_in_staging_buf <= 0)
 				m_data_in_staging_buf = 0;
-			m_data_offset = 0;
 		}
 
 		unsigned int data_left = m_data_in_staging_buf - m_data_offset;


### PR DESCRIPTION
The ‘ReadRawData()’ procedure in the ‘SCPITMCTransport’ class has been extended so that multiple packets can be read from the RTB2000.
Otherwise, only the first packet is read and data transfer is interrupted at more than ~ 40 kB.

The transfer also works with the PR: [https://github.com/ngscopeclient/scopehal/pull/950](https://github.com/ngscopeclient/scopehal/pull/950)
However, I was unable to use the progress bar, as it causes the program to crash.

Modified files:
scopehal/SCPITMCTransport.cpp