### PR TITLE
Fix Agilent DSO-X 2000 series support.

### DIFF
--- a/scopehal/SCPIDevice.h
+++ b/scopehal/SCPIDevice.h
@@ -36,7 +36,7 @@
 class SCPIDevice
 {
 public:
-	SCPIDevice(SCPITransport* transport, bool identify = true);
+	SCPIDevice(SCPITransport* transport, bool identify = true, unsigned int identify_timeout_us = 5000000);
 	virtual ~SCPIDevice();
 
 	SCPITransport* GetTransport() const


### PR DESCRIPTION
Fixes support for Agilent/Keysight DSO-X 2000 series scopes, and probably others.

Part of this involves adding a hack in the SCPIDevice ctor to optionally specify a longer timeout after initial connection. This is needed because at least the 2000 series scopes have a delay of about 10 seconds between accepting a SCPI connection and being able to generate their first response.

From testing on my DSO-X 2024A, if you connect to SCPI (port 5025) and wait about 10 seconds, then send `*IDN?`, it will respond immediately. If you instead send `*IDN?` as soon as you connect, the response will take about 10 seconds to appear. So this does not appear to be a delay specifically associated with the identify command; rather, it is some setup happening upon accepting a SCPI connection.