### PR TITLE
AgilentOscilloscope: implement ForceTrigger

### DIFF
--- a/scopehal/AgilentOscilloscope.cpp
+++ b/scopehal/AgilentOscilloscope.cpp
@@ -857,7 +857,11 @@ void AgilentOscilloscope::Stop()
 
 void AgilentOscilloscope::ForceTrigger()
 {
-	LogError("AgilentOscilloscope::ForceTrigger not implemented\n");
+	lock_guard<recursive_mutex> lock(m_mutex);
+	m_transport->SendCommand(":SING");
+	m_transport->SendCommand(":TRIG:FORC");
+	m_triggerArmed = true;
+	m_triggerOneShot = true;
 }
 
 bool AgilentOscilloscope::IsTriggerArmed()


### PR DESCRIPTION
ForceTrigger was previously not implemented for Keysight/Agilent oscilloscopes. This patch implements the Force Trigger function. 

The change was tested on my Keysight DSOX-1204A.
