### PR TITLE
Fix warnings associated with SCPITransport::SetTimeouts()

### DIFF
--- a/scopehal/SCPISocketTransport.h
+++ b/scopehal/SCPISocketTransport.h
@@ -81,7 +81,7 @@ public:
 		@param txUs		Send timeout, in microseconds
 		@param rxUs		Receive timeout, in microseconds
 	 */
-	bool SetTimeouts(unsigned int txUs, unsigned int rxUs)
+	bool SetTimeouts(unsigned int txUs, unsigned int rxUs) override
 	{
 		bool success = m_socket.SetTxTimeout(txUs);
 		success = success & m_socket.SetRxTimeout(rxUs);

--- a/scopehal/SCPITransport.cpp
+++ b/scopehal/SCPITransport.cpp
@@ -318,7 +318,7 @@ vector<TransportEndpoint> SCPITransport::EnumTransportEndpoints()
 /** 
 	@brief Base implementation does nothing
 */
-bool SCPITransport::SetTimeouts(unsigned int txUs, unsigned int rxUs){
+bool SCPITransport::SetTimeouts([[maybe_unused]] unsigned int txUs, [[maybe_unused]]unsigned int rxUs){
 	LogWarning("SetTimeouts() not implemented for this transport\n");
 	return false;
 }


### PR DESCRIPTION
Resolve warnings generated by Clang in CI:
https://dashboard.ngscopeclient.org/builds/1337/build

```
[/.../scopehal-apps/lib/scopehal/../scopehal/SCPISocketTransport.h:84:7](https://github.com/ngscopeclient/scopehal-apps/blob/77556527ece187f5f7fa3e830724517fa343b05f/lib/scopehal/SCPISocketTransport.h): error: 'SetTimeouts' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
   84 |         bool SetTimeouts(unsigned int txUs, unsigned int rxUs)
      |
```

Resolve warning generated by gcc and probably also Clang:

```
C:/msys64/home/tim/repos/scopehal-apps/lib/scopehal/SCPITransport.cpp:321:46: warning: unused parameter 'txUs' [-Wunused-parameter]
  321 | bool SCPITransport::SetTimeouts(unsigned int txUs, unsigned int rxUs){
      |                                 ~~~~~~~~~~~~~^~~~
C:/msys64/home/tim/repos/scopehal-apps/lib/scopehal/SCPITransport.cpp:321:65: warning: unused parameter 'rxUs' [-Wunused-parameter]
  321 | bool SCPITransport::SetTimeouts(unsigned int txUs, unsigned int rxUs){
      |                                                    ~~~~~~~~~~~~~^~~~
```